### PR TITLE
Fix scroll viewport selector

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -76,9 +76,13 @@ export default function App() {
 
   useEffect(() => {
     if (scrollAreaRef.current) {
-      const scrollViewport = scrollAreaRef.current.querySelector(
-        "[data-radix-scroll-area-viewport]"
-      );
+      const scrollViewport =
+        scrollAreaRef.current.querySelector(
+          "[data-slot=\"scroll-area-viewport\"]"
+        ) ||
+        scrollAreaRef.current.querySelector(
+          "[data-radix-scroll-area-viewport]"
+        );
       if (scrollViewport) {
         scrollViewport.scrollTop = scrollViewport.scrollHeight;
       }

--- a/frontend/src/components/ui/scroll-area.tsx
+++ b/frontend/src/components/ui/scroll-area.tsx
@@ -3,14 +3,14 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 
 import { cn } from "@/lib/utils"
 
-function ScrollArea({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
+      ref={ref}
       className={cn("relative", className)}
       {...props}
     >
@@ -24,7 +24,9 @@ function ScrollArea({
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
   )
-}
+})
+
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
 
 function ScrollBar({
   className,


### PR DESCRIPTION
## Summary
- handle scroll area viewport for both data-slot and data-radix attributes

## Testing
- `npm run build` *(fails: Cannot find module 'react', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6842680b3da08326aadb0a2d8929ecaf